### PR TITLE
Some fixes in the `fps` function

### DIFF
--- a/+torsche/@taskset/plot.m
+++ b/+torsche/@taskset/plot.m
@@ -25,6 +25,7 @@ function varargout=plot(T, varargin)
 %    - 0 - Black & White
 %    - 1 - Generate colors only for tasks without color
 %    - 2 - Generate colors for all tasks 
+%    - 2 - Generate one color for each processor
 %    - default value is 1)
 %  ASAP:
 %    - 0 - normal draw (default)
@@ -235,6 +236,17 @@ end
 % coloring
 if setcol == 0
     col = ones(length(T.tasks),3);
+elseif setcol == 3
+    % one color per processor
+    try
+        processors = cellfun(@(t) t.Processor, T.tasks);
+        col_tmp = torsche.colorfromcolormap(max(processors));
+        col = zeros(length(T.tasks),3);
+        col(1:length(T.tasks),:) = col_tmp(processors,:);
+    catch
+        warning('Processors not well defined, not colouring...');
+        col = ones(length(T.tasks),3);
+    end
 else
     %col = colorcube(length(T.tasks)+8);
     col = torsche.colorfromcolormap(length(T.tasks));

--- a/+torsche/fps.m
+++ b/+torsche/fps.m
@@ -89,6 +89,7 @@ while(tmax < tstop)
             temptask = pts.parent;
             temptask.Processor = i; % Hack for plotting the schedule
             temptask.ReleaseTime = tmax;
+            temptask.Deadline = temptask.Deadline + tmax;
             readyTasks{i} = temptask;
         end
     end

--- a/+torsche/fps.m
+++ b/+torsche/fps.m
@@ -76,24 +76,27 @@ tstop = 1;
 for i = 1:noft
     tstop = lcm(tstop, per(i));
 end
-   
 
-while(tmax < tstop)
-    offs = mod(tmax, per);
-    for i=1:noft
-        if (offs(i) == 0)
-            
-            ready(i)=c(i); % put the tasks to the ready set
-            pt = ts.tasks(i);
+% Procedure to add to the ready queue all tasks released at time t.
+function add_to_ready(t)
+    offs = mod(t, per);
+    for j=1:noft
+        if (offs(j) == 0)
+            ready(j)=c(j); % put the tasks to the ready set
+            pt = ts.tasks(j);
             pts = struct(pt);
             temptask = pts.parent;
-            temptask.Processor = i; % Hack for plotting the schedule
-            temptask.ReleaseTime = tmax;
-            temptask.Deadline = temptask.Deadline + tmax;
-            readyTasks{i} = temptask;
+            temptask.Processor = j; % Hack for plotting the schedule
+            temptask.ReleaseTime = t;
+            temptask.Deadline = temptask.Deadline + t;
+            readyTasks{j} = temptask;
         end
     end
-   
+end
+
+while(tmax < tstop)
+
+    add_to_ready(tmax);
     
     schedtask=-1; %  -1 means the idle task
     maxprio=1;
@@ -125,6 +128,11 @@ while(tmax < tstop)
         readyTasks{schedtask} = add_scht(readyTasks{schedtask}, start, len, processor);
         ready(schedtask)= 0;
         
+        % check for tasks released during the execution time
+        for t = tmax + 1 : tmax + executed - 1
+            add_to_ready(t);
+        end
+        
         if any(ready)
             tmax = tmax + executed;
         else
@@ -138,3 +146,5 @@ while(tmax < tstop)
      end
 end
 add_schedule(resultts, 'Fixed priority schedule');
+
+end


### PR DESCRIPTION
Hello. I have observed some problems in the `fps()` function. For example, the following snippets generates the plot below (using MATLAB R2017b). I tried to fix them with this pull request.

```matlab
t1 = torsche.ptask('\tau_1',  2,  20, 0,  6);
t2 = torsche.ptask('\tau_2',  3,   7, 0,  7);
t3 = torsche.ptask('\tau_3',  5,  14, 0, 13);
t4 = torsche.ptask('\tau_4',  4, 100, 0, 60);
t1.Weight = 4;
t2.Weight = 3;
t3.Weight = 2;
t4.Weight = 1;
T = torsche.taskset([t1 t2 t3 t4]);
sched = torsche.fps(T);
colormap jet
plot(sched, 'Proc', 1, 'Axname', {'\tau_1', '\tau_2', '\tau_3', '\tau_4'}, 'Color', 3);
```

![scheduling_flawed](https://user-images.githubusercontent.com/8300317/31392447-914200e8-add9-11e7-95b4-08ed5d2853c2.png)